### PR TITLE
feat: disable body access for GRPC

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
           CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 
   e2e-test:
-    name: E2E Test
+    name: E2E Testing
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/context.go
+++ b/context.go
@@ -91,21 +91,29 @@ type HttpFilterContext interface {
 	//
 	SetResponseBody(buffer api.BufferInstance, endStream bool)
 
+	// IsRequestBodyAccessible checks if the request body is accessible for reading or writing.
+	//
+	IsRequestBodyAccessible() bool
+
 	// IsRequestBodyReadable specifies whether an HTTP Request body is readable or not.
 	//
 	IsRequestBodyReadable() bool
 
-	// IsRequestBodyWriteable specifies whether an HTTP Request body is writeable or not.
+	// IsRequestBodyWritable specifies whether an HTTP Request body is writeable or not.
 	//
-	IsRequestBodyWriteable() bool
+	IsRequestBodyWritable() bool
+
+	// IsResponseBodyAccessible checks if the response body is accessible for reading or writing.
+	//
+	IsResponseBodyAccessible() bool
 
 	// IsResponseBodyReadable specifies whether an HTTP Response body is readable or not.
 	//
 	IsResponseBodyReadable() bool
 
-	// IsResponseBodyWriteable specifies whether an HTTP Response body is writeable or not.
+	// IsResponseBodyWritable specifies whether an HTTP Response body is writeable or not.
 	//
-	IsResponseBodyWriteable() bool
+	IsResponseBodyWritable() bool
 
 	// JSON sends a JSON response with a status code.
 	//

--- a/context_test.go
+++ b/context_test.go
@@ -4,12 +4,150 @@ import (
 	"testing"
 
 	mock_envoy "github.com/ardikabs/gonvoy/test/mock/envoy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-func fakeDummyContext(t *testing.T) Context {
+func fakeDummyContext(t *testing.T, opts ...ContextOption) Context {
 	fc := mock_envoy.NewFilterCallbackHandler(t)
-	c, err := NewContext(fc)
+	c, err := NewContext(fc, opts...)
 	require.NoError(t, err)
 	return c
+}
+
+func TestContext(t *testing.T) {
+
+	t.Run("Request Body Accessibility", func(t *testing.T) {
+		testcases := []struct {
+			name           string
+			config         *globalConfig
+			contentType    string
+			contentLength  string
+			expectedAccess bool
+			expectedRead   bool
+			expectedWrite  bool
+		}{
+			{
+				name: "non-writeable| content-type: application/json, content-length: 100",
+				config: &globalConfig{
+					strictBodyAccess:     false,
+					allowRequestBodyRead: true,
+				},
+				contentType:    MIMEApplicationJSON,
+				expectedAccess: true,
+				expectedRead:   true,
+				expectedWrite:  false,
+			},
+			{
+				name: "body accessible| content-type: application/json, content-length: 100",
+				config: &globalConfig{
+					strictBodyAccess:      false,
+					allowRequestBodyWrite: true,
+				},
+				contentType:    MIMEApplicationJSON,
+				contentLength:  "100",
+				expectedAccess: true,
+				expectedRead:   true,
+				expectedWrite:  true,
+			},
+			{
+				name: "body accessible| content-type: application/json and data chunked",
+				config: &globalConfig{
+					strictBodyAccess:      false,
+					allowRequestBodyWrite: true,
+				},
+				contentType:    MIMEApplicationJSON,
+				expectedAccess: true,
+				expectedRead:   true,
+				expectedWrite:  true,
+			},
+			{
+				name: "body accessible| content-type: application/ld+json, content-length: 100",
+				config: &globalConfig{
+					strictBodyAccess:     false,
+					allowRequestBodyRead: true,
+				},
+				contentType:    "application/ld+json",
+				contentLength:  "100",
+				expectedAccess: true,
+				expectedRead:   true,
+				expectedWrite:  false,
+			},
+			{
+				name: "body inaccessible| content-type: application/ld+json and data chunked (no content-length)",
+				config: &globalConfig{
+					strictBodyAccess:     false,
+					allowRequestBodyRead: true,
+				},
+				contentType:    "application/ld+json",
+				expectedAccess: false,
+				expectedRead:   false,
+				expectedWrite:  false,
+			},
+			{
+				name: "body inaccessible| content-type: application/grpc",
+				config: &globalConfig{
+					strictBodyAccess:     false,
+					allowRequestBodyRead: true,
+				},
+				contentType:    MIMEApplicationGRPC,
+				expectedAccess: false,
+				expectedRead:   false,
+				expectedWrite:  false,
+			},
+			{
+				name: "body inaccessible| content-type: application/grpc+",
+				config: &globalConfig{
+					strictBodyAccess:     false,
+					allowRequestBodyRead: true,
+				},
+				contentType:    "application/grpc+proto",
+				expectedAccess: false,
+				expectedRead:   false,
+				expectedWrite:  false,
+			},
+			{
+				name: "body accessible for non-grpc| content-type: application/grpc-web, content-length: 100",
+				config: &globalConfig{
+					strictBodyAccess:     false,
+					allowRequestBodyRead: true,
+				},
+				contentType:    "application/grpc-web",
+				contentLength:  "100",
+				expectedAccess: true,
+				expectedRead:   true,
+				expectedWrite:  false,
+			},
+		}
+
+		for _, tc := range testcases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				reqHeaderMapMock := mock_envoy.NewRequestHeaderMap(t)
+				reqHeaderMapMock.EXPECT().Host().Return("example.com")
+				reqHeaderMapMock.EXPECT().Method().Return("GET")
+				reqHeaderMapMock.EXPECT().Path().Return("/")
+				reqHeaderMapMock.EXPECT().Range(mock.Anything).Run(func(f func(string, string) bool) {
+					headers := map[string]string{
+						"content-type":   tc.contentType,
+						"content-length": tc.contentLength,
+					}
+
+					for k, v := range headers {
+						f(k, v)
+					}
+				})
+
+				ctx := fakeDummyContext(t, WithContextConfig(tc.config))
+				ctx.SetRequestHeader(reqHeaderMapMock)
+
+				assert.Equal(t, tc.expectedAccess, ctx.IsRequestBodyAccessible())
+				assert.Equal(t, tc.expectedRead, ctx.IsRequestBodyReadable())
+				assert.Equal(t, tc.expectedWrite, ctx.IsRequestBodyWritable())
+			})
+		}
+	})
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,4 +19,12 @@ services:
     # if you are using Apple M1, use below image, otherwise above.
     image: kicbase/echo-server:1.0
   podinfo_service:
-    image: ghcr.io/stefanprodan/podinfo:6.5.0
+    image: ghcr.io/stefanprodan/podinfo:6.6.2
+  grpc_podinfo_service:
+    image: ghcr.io/stefanprodan/podinfo:6.6.2
+    command:
+      - ./podinfo
+      - --port=9898
+      - --grpc-port=9999
+      - --grpc-service-name=podinfo
+      - --level=info

--- a/example/go-simple-extension/envoy.yaml
+++ b/example/go-simple-extension/envoy.yaml
@@ -100,6 +100,11 @@ static_resources:
                     - name: local_service
                       domains: ["*"]
                       routes:
+                        - name: grpc
+                          match:
+                            prefix: "/echo.EchoService/Echo"
+                          route:
+                            cluster: grpc_podinfo_service_cluster
                         - name: details-page
                           match:
                             prefix: "/details"
@@ -207,6 +212,24 @@ static_resources:
                     socket_address:
                       address: podinfo_service
                       port_value: 9898
+    - name: grpc_podinfo_service_cluster
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: grpc_podinfo_service_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: grpc_podinfo_service
+                      port_value: 9999
+
     - name: raw.githubusercontent.com||443
       type: STRICT_DNS
       lb_policy: ROUND_ROBIN

--- a/example/go-simple-extension/myfilter/handler/handler_three.go
+++ b/example/go-simple-extension/myfilter/handler/handler_three.go
@@ -35,7 +35,7 @@ func (h *HandlerThree) OnRequestHeader(c gonvoy.Context) error {
 }
 
 func (h *HandlerThree) OnRequestBody(c gonvoy.Context) error {
-	if ct := c.Request().Header.Get(gonvoy.HeaderContentType); !strings.Contains(ct, "application/json") {
+	if ct := c.Request().Header.Get(gonvoy.HeaderContentType); !strings.Contains(ct, gonvoy.MIMEApplicationJSON) {
 		return nil
 	}
 
@@ -48,7 +48,7 @@ func (h *HandlerThree) OnRequestBody(c gonvoy.Context) error {
 	reqBody["handlerName"] = "HandlerThree"
 	reqBody["phase"] = "HTTPRequest"
 
-	if c.IsRequestBodyWriteable() {
+	if c.IsRequestBodyWritable() {
 		enc := json.NewEncoder(c.RequestBody())
 		return enc.Encode(reqBody)
 	}
@@ -59,6 +59,7 @@ func (h *HandlerThree) OnRequestBody(c gonvoy.Context) error {
 	}
 
 	c.Log().Info("check request body", "payload", string(b))
+
 	return nil
 }
 
@@ -85,7 +86,7 @@ func (h *HandlerThree) OnResponseHeader(c gonvoy.Context) error {
 }
 
 func (h *HandlerThree) OnResponseBody(c gonvoy.Context) error {
-	if ct := c.Response().Header.Get(gonvoy.HeaderContentType); !strings.Contains(ct, "application/json") {
+	if ct := c.Response().Header.Get(gonvoy.HeaderContentType); !strings.Contains(ct, gonvoy.MIMEApplicationJSON) {
 		return nil
 	}
 

--- a/header.go
+++ b/header.go
@@ -28,6 +28,7 @@ const (
 	MIMEApplicationJSONCharsetUTF8 = MIMEApplicationJSON + "; " + charsetUTF8
 	MIMEApplicationXML             = "application/xml"
 	MIMEApplicationXMLCharsetUTF8  = MIMEApplicationXML + "; " + charsetUTF8
+	MIMEApplicationGRPC            = "application/grpc"
 	MIMETextXML                    = "text/xml"
 	MIMETextXMLCharsetUTF8         = MIMETextXML + "; " + charsetUTF8
 	MIMEApplicationForm            = "application/x-www-form-urlencoded"

--- a/httpfilter_impl.go
+++ b/httpfilter_impl.go
@@ -13,9 +13,7 @@ type httpFilterImpl struct {
 
 func (f *httpFilterImpl) OnLog() { f.srv.Finalize() }
 
-func (f *httpFilterImpl) OnDestroy(reason api.DestroyReason) {
-	f.srv = nil
-}
+func (f *httpFilterImpl) OnDestroy(reason api.DestroyReason) { f.srv = nil }
 
 func (f *httpFilterImpl) DecodeHeaders(header api.RequestHeaderMap, endStream bool) api.StatusType {
 	result := f.srv.ServeDecodeFilter(f.handleRequestHeader(header))
@@ -45,7 +43,7 @@ func (f *httpFilterImpl) handleRequestHeader(header api.RequestHeaderMap) HttpFi
 			return ActionContinue, err
 		}
 
-		if c.IsRequestBodyWriteable() {
+		if c.IsRequestBodyWritable() {
 			return ActionPause, nil
 		}
 
@@ -55,7 +53,7 @@ func (f *httpFilterImpl) handleRequestHeader(header api.RequestHeaderMap) HttpFi
 
 func (f *httpFilterImpl) handleRequestBody(buffer api.BufferInstance, endStream bool) HttpFilterDecoderFunc {
 	return func(c Context, p HttpFilterDecodeProcessor) (HttpFilterAction, error) {
-		if !isRequestBodyAccessible(c) {
+		if !c.IsRequestBodyAccessible() {
 			return ActionSkip, nil
 		}
 
@@ -104,7 +102,7 @@ func (f *httpFilterImpl) handleResponseHeader(header api.ResponseHeaderMap) Http
 // Code references: https://github.com/envoyproxy/envoy/blob/v1.29.4/contrib/golang/filters/http/source/processor_state.cc#L362-L371.
 func (f *httpFilterImpl) handleResponseBody(buffer api.BufferInstance, endStream bool) HttpFilterEncoderFunc {
 	return func(c Context, p HttpFilterEncodeProcessor) (HttpFilterAction, error) {
-		if !isResponseBodyAccessible(c) {
+		if !c.IsResponseBodyAccessible() {
 			return ActionSkip, nil
 		}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -97,3 +97,14 @@ func GetAbsPathFromCaller(skip int) (string, error) {
 
 	return filepath.Dir(absPath), nil
 }
+
+// StringStartsWith checks if a string starts with any of the prefixes.
+func StringStartsWith(s string, prefixes ...string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -119,3 +119,30 @@ func TestGetAbsPathFromCaller(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, wd, path)
 }
+
+func TestStringStartsWith(t *testing.T) {
+	t.Run("empty string", func(t *testing.T) {
+		result := util.StringStartsWith("", "prefix")
+		assert.False(t, result)
+	})
+
+	t.Run("string starts with prefix", func(t *testing.T) {
+		result := util.StringStartsWith("prefix123", "prefix")
+		assert.True(t, result)
+	})
+
+	t.Run("string does not start with prefix", func(t *testing.T) {
+		result := util.StringStartsWith("suffix123", "prefix")
+		assert.False(t, result)
+	})
+
+	t.Run("string starts with any of the prefixes", func(t *testing.T) {
+		result := util.StringStartsWith("prefix123", "suffix", "prefix")
+		assert.True(t, result)
+	})
+
+	t.Run("string does not start with any of the prefixes", func(t *testing.T) {
+		result := util.StringStartsWith("suffix123", "prefix1", "prefix2")
+		assert.False(t, result)
+	})
+}

--- a/zz_generated.context_test.go
+++ b/zz_generated.context_test.go
@@ -205,6 +205,47 @@ func (_c *MockContext_GetProperty_Call) RunAndReturn(run func(string, string) (s
 	return _c
 }
 
+// IsRequestBodyAccessible provides a mock function with given fields:
+func (_m *MockContext) IsRequestBodyAccessible() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockContext_IsRequestBodyAccessible_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsRequestBodyAccessible'
+type MockContext_IsRequestBodyAccessible_Call struct {
+	*mock.Call
+}
+
+// IsRequestBodyAccessible is a helper method to define mock.On call
+func (_e *MockContext_Expecter) IsRequestBodyAccessible() *MockContext_IsRequestBodyAccessible_Call {
+	return &MockContext_IsRequestBodyAccessible_Call{Call: _e.mock.On("IsRequestBodyAccessible")}
+}
+
+func (_c *MockContext_IsRequestBodyAccessible_Call) Run(run func()) *MockContext_IsRequestBodyAccessible_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContext_IsRequestBodyAccessible_Call) Return(_a0 bool) *MockContext_IsRequestBodyAccessible_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockContext_IsRequestBodyAccessible_Call) RunAndReturn(run func() bool) *MockContext_IsRequestBodyAccessible_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsRequestBodyReadable provides a mock function with given fields:
 func (_m *MockContext) IsRequestBodyReadable() bool {
 	ret := _m.Called()
@@ -246,8 +287,8 @@ func (_c *MockContext_IsRequestBodyReadable_Call) RunAndReturn(run func() bool) 
 	return _c
 }
 
-// IsRequestBodyWriteable provides a mock function with given fields:
-func (_m *MockContext) IsRequestBodyWriteable() bool {
+// IsRequestBodyWritable provides a mock function with given fields:
+func (_m *MockContext) IsRequestBodyWritable() bool {
 	ret := _m.Called()
 
 	var r0 bool
@@ -260,29 +301,70 @@ func (_m *MockContext) IsRequestBodyWriteable() bool {
 	return r0
 }
 
-// MockContext_IsRequestBodyWriteable_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsRequestBodyWriteable'
-type MockContext_IsRequestBodyWriteable_Call struct {
+// MockContext_IsRequestBodyWritable_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsRequestBodyWritable'
+type MockContext_IsRequestBodyWritable_Call struct {
 	*mock.Call
 }
 
-// IsRequestBodyWriteable is a helper method to define mock.On call
-func (_e *MockContext_Expecter) IsRequestBodyWriteable() *MockContext_IsRequestBodyWriteable_Call {
-	return &MockContext_IsRequestBodyWriteable_Call{Call: _e.mock.On("IsRequestBodyWriteable")}
+// IsRequestBodyWritable is a helper method to define mock.On call
+func (_e *MockContext_Expecter) IsRequestBodyWritable() *MockContext_IsRequestBodyWritable_Call {
+	return &MockContext_IsRequestBodyWritable_Call{Call: _e.mock.On("IsRequestBodyWritable")}
 }
 
-func (_c *MockContext_IsRequestBodyWriteable_Call) Run(run func()) *MockContext_IsRequestBodyWriteable_Call {
+func (_c *MockContext_IsRequestBodyWritable_Call) Run(run func()) *MockContext_IsRequestBodyWritable_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockContext_IsRequestBodyWriteable_Call) Return(_a0 bool) *MockContext_IsRequestBodyWriteable_Call {
+func (_c *MockContext_IsRequestBodyWritable_Call) Return(_a0 bool) *MockContext_IsRequestBodyWritable_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockContext_IsRequestBodyWriteable_Call) RunAndReturn(run func() bool) *MockContext_IsRequestBodyWriteable_Call {
+func (_c *MockContext_IsRequestBodyWritable_Call) RunAndReturn(run func() bool) *MockContext_IsRequestBodyWritable_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsResponseBodyAccessible provides a mock function with given fields:
+func (_m *MockContext) IsResponseBodyAccessible() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockContext_IsResponseBodyAccessible_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsResponseBodyAccessible'
+type MockContext_IsResponseBodyAccessible_Call struct {
+	*mock.Call
+}
+
+// IsResponseBodyAccessible is a helper method to define mock.On call
+func (_e *MockContext_Expecter) IsResponseBodyAccessible() *MockContext_IsResponseBodyAccessible_Call {
+	return &MockContext_IsResponseBodyAccessible_Call{Call: _e.mock.On("IsResponseBodyAccessible")}
+}
+
+func (_c *MockContext_IsResponseBodyAccessible_Call) Run(run func()) *MockContext_IsResponseBodyAccessible_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockContext_IsResponseBodyAccessible_Call) Return(_a0 bool) *MockContext_IsResponseBodyAccessible_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockContext_IsResponseBodyAccessible_Call) RunAndReturn(run func() bool) *MockContext_IsResponseBodyAccessible_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -328,8 +410,8 @@ func (_c *MockContext_IsResponseBodyReadable_Call) RunAndReturn(run func() bool)
 	return _c
 }
 
-// IsResponseBodyWriteable provides a mock function with given fields:
-func (_m *MockContext) IsResponseBodyWriteable() bool {
+// IsResponseBodyWritable provides a mock function with given fields:
+func (_m *MockContext) IsResponseBodyWritable() bool {
 	ret := _m.Called()
 
 	var r0 bool
@@ -342,29 +424,29 @@ func (_m *MockContext) IsResponseBodyWriteable() bool {
 	return r0
 }
 
-// MockContext_IsResponseBodyWriteable_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsResponseBodyWriteable'
-type MockContext_IsResponseBodyWriteable_Call struct {
+// MockContext_IsResponseBodyWritable_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsResponseBodyWritable'
+type MockContext_IsResponseBodyWritable_Call struct {
 	*mock.Call
 }
 
-// IsResponseBodyWriteable is a helper method to define mock.On call
-func (_e *MockContext_Expecter) IsResponseBodyWriteable() *MockContext_IsResponseBodyWriteable_Call {
-	return &MockContext_IsResponseBodyWriteable_Call{Call: _e.mock.On("IsResponseBodyWriteable")}
+// IsResponseBodyWritable is a helper method to define mock.On call
+func (_e *MockContext_Expecter) IsResponseBodyWritable() *MockContext_IsResponseBodyWritable_Call {
+	return &MockContext_IsResponseBodyWritable_Call{Call: _e.mock.On("IsResponseBodyWritable")}
 }
 
-func (_c *MockContext_IsResponseBodyWriteable_Call) Run(run func()) *MockContext_IsResponseBodyWriteable_Call {
+func (_c *MockContext_IsResponseBodyWritable_Call) Run(run func()) *MockContext_IsResponseBodyWritable_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockContext_IsResponseBodyWriteable_Call) Return(_a0 bool) *MockContext_IsResponseBodyWriteable_Call {
+func (_c *MockContext_IsResponseBodyWritable_Call) Return(_a0 bool) *MockContext_IsResponseBodyWritable_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockContext_IsResponseBodyWriteable_Call) RunAndReturn(run func() bool) *MockContext_IsResponseBodyWriteable_Call {
+func (_c *MockContext_IsResponseBodyWritable_Call) RunAndReturn(run func() bool) *MockContext_IsResponseBodyWritable_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
It is blocked via the Content-Type header; if the Content-Type is `application/grpc` or starts with `application/grpc+`, body access will be prevented regardless of the configuration.

Closes #54 