### PR TITLE
refactor!(context): simplify send response methods

### DIFF
--- a/context.go
+++ b/context.go
@@ -115,15 +115,23 @@ type HttpFilterContext interface {
 	//
 	IsResponseBodyWritable() bool
 
-	// JSON sends a JSON response with a status code.
+	// SendResponse dispatches a response with a specified status code, body, and optional localreply options.
+	// Use the JSON() method when you need to respond with a JSON content-type.
+	// For plain text responses, use the String() method.
+	// Use SendResponse only when you need to send a response with a custom content type.
 	//
 	// This action halts the handler chaining and immediately returns back to Envoy.
-	JSON(code int, b []byte, header http.Header, opts ...ReplyOption) error
+	SendResponse(code int, bodyText string, opts ...LocalReplyOption) error
 
-	// String sends a plain text response with a status code.
+	// JSON dispatches a JSON response with a status code.
 	//
 	// This action halts the handler chaining and immediately returns back to Envoy.
-	String(code int, s string, header http.Header, opts ...ReplyOption) error
+	JSON(code int, b []byte, opts ...LocalReplyOption) error
+
+	// String dispatches a plain text response with a status code.
+	//
+	// This action halts the handler chaining and immediately returns back to Envoy.
+	String(code int, s string, opts ...LocalReplyOption) error
 
 	// SkipNextPhase immediately returns to the Envoy without further progressing to the next handler.
 	// This action also enables users to bypass the next phase.

--- a/context_test.go
+++ b/context_test.go
@@ -103,6 +103,7 @@ func TestContext(t *testing.T) {
 					allowRequestBodyRead: true,
 				},
 				contentType:    "application/grpc+proto",
+				contentLength:  "100",
 				expectedAccess: false,
 				expectedRead:   false,
 				expectedWrite:  false,

--- a/example/go-simple-extension/myfilter/handler/handler_three.go
+++ b/example/go-simple-extension/myfilter/handler/handler_three.go
@@ -66,20 +66,28 @@ func (h *HandlerThree) OnRequestBody(c gonvoy.Context) error {
 func (h *HandlerThree) OnResponseHeader(c gonvoy.Context) error {
 	switch sc := c.Response().StatusCode; sc {
 	case http.StatusUnauthorized:
+		headers := gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader())
+		details := gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)
 		return c.JSON(sc,
 			gonvoy.NewMinimalJSONResponse("UNAUTHORIZED", "UNAUTHORIZED"),
-			gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader()),
-			gonvoy.WithResponseCodeDetails(gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)))
+			gonvoy.LocalReplyWithHTTPHeaders(headers),
+			gonvoy.LocalReplyWithRCDetails(details))
+
 	case http.StatusTooManyRequests:
+		headers := gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader())
+		details := gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)
 		return c.JSON(sc,
 			gonvoy.NewMinimalJSONResponse("TOO_MANY_REQUESTS", "TOO_MANY_REQUESTS"),
-			gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader()),
-			gonvoy.WithResponseCodeDetails(gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)))
+			gonvoy.LocalReplyWithHTTPHeaders(headers),
+			gonvoy.LocalReplyWithRCDetails(details))
+
 	case http.StatusServiceUnavailable:
+		headers := gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader())
+		details := gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)
 		return c.JSON(sc,
 			gonvoy.NewMinimalJSONResponse("SERVICE_UNAVAILABLE", "SERVICE_UNAVAILABLE"),
-			gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader()),
-			gonvoy.WithResponseCodeDetails(gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)))
+			gonvoy.LocalReplyWithHTTPHeaders(headers),
+			gonvoy.LocalReplyWithRCDetails(details))
 	}
 
 	return nil

--- a/example/go-simple-extension/myfilter/handler/handler_two.go
+++ b/example/go-simple-extension/myfilter/handler/handler_two.go
@@ -21,15 +21,15 @@ func (h *HandlerTwo) OnRequestHeader(c gonvoy.Context) error {
 	header := c.Request().Header
 
 	if header.Get("x-error") == "403" {
-		return c.String(http.StatusForbidden, "access denied", gonvoy.NewGatewayHeaders())
+		return c.String(http.StatusForbidden, "access denied", gonvoy.LocalReplyWithHTTPHeaders(gonvoy.NewGatewayHeaders()))
 	}
 
 	if header.Get("x-error") == "429" {
-		return c.String(http.StatusTooManyRequests, "rate limit exceeded", gonvoy.NewGatewayHeaders())
+		return c.String(http.StatusTooManyRequests, "rate limit exceeded", gonvoy.LocalReplyWithHTTPHeaders(gonvoy.NewGatewayHeaders()))
 	}
 
 	if header.Get("x-error") == "503" {
-		return c.String(http.StatusServiceUnavailable, "service unavailable", gonvoy.NewGatewayHeaders())
+		return c.String(http.StatusServiceUnavailable, "service unavailable", gonvoy.LocalReplyWithHTTPHeaders(gonvoy.NewGatewayHeaders()))
 	}
 
 	data := new(globaldata)

--- a/httpfilter_handler.go
+++ b/httpfilter_handler.go
@@ -55,25 +55,19 @@ func DefaultErrorHandler(c Context, err error) api.StatusType {
 
 	switch unwrapErr {
 	case errs.ErrUnauthorized:
-		err = c.JSON(
-			http.StatusUnauthorized,
-			ResponseUnauthorized,
-			NewGatewayHeaders(),
-			WithResponseCodeDetails(DefaultResponseCodeDetailUnauthorized.Wrap(err.Error())))
+		err = c.JSON(http.StatusUnauthorized, ResponseUnauthorized,
+			LocalReplyWithHTTPHeaders(NewGatewayHeaders()),
+			LocalReplyWithRCDetails(DefaultResponseCodeDetailUnauthorized.Wrap(err.Error())))
 
 	case errs.ErrAccessDenied:
-		err = c.JSON(
-			http.StatusForbidden,
-			ResponseForbidden,
-			NewGatewayHeaders(),
-			WithResponseCodeDetails(DefaultResponseCodeDetailAccessDenied.Wrap(err.Error())))
+		err = c.JSON(http.StatusForbidden, ResponseForbidden,
+			LocalReplyWithHTTPHeaders(NewGatewayHeaders()),
+			LocalReplyWithRCDetails(DefaultResponseCodeDetailAccessDenied.Wrap(err.Error())))
 
 	case errs.ErrOperationNotPermitted:
-		err = c.JSON(
-			http.StatusBadGateway,
-			NewMinimalJSONResponse("BAD_GATEWAY", "BAD_GATEWAY", err),
-			NewGatewayHeaders(),
-			WithResponseCodeDetails(DefaultResponseCodeDetailError.Wrap(err.Error())))
+		err = c.JSON(http.StatusBadGateway, NewMinimalJSONResponse("BAD_GATEWAY", "BAD_GATEWAY", err),
+			LocalReplyWithHTTPHeaders(NewGatewayHeaders()),
+			LocalReplyWithRCDetails(DefaultResponseCodeDetailError.Wrap(err.Error())))
 
 	default:
 		log := c.Log().WithCallDepth(3)
@@ -87,11 +81,9 @@ func DefaultErrorHandler(c Context, err error) api.StatusType {
 		method := MustGetProperty(c, "request.method", "-")
 		path := MustGetProperty(c, "request.path", "-")
 		log.Error(err, "unidentified error", "host", host, "method", method, "path", path)
-		err = c.JSON(
-			http.StatusInternalServerError,
-			ResponseInternalServerError,
-			NewGatewayHeaders(),
-			WithResponseCodeDetails(DefaultResponseCodeDetailError.Wrap(err.Error())))
+		err = c.JSON(http.StatusInternalServerError, ResponseInternalServerError,
+			LocalReplyWithHTTPHeaders(NewGatewayHeaders()),
+			LocalReplyWithRCDetails(DefaultResponseCodeDetailError.Wrap(err.Error())))
 	}
 
 	if err != nil {

--- a/reply_options.go
+++ b/reply_options.go
@@ -2,6 +2,7 @@ package gonvoy
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/ardikabs/gonvoy/pkg/util"
@@ -31,16 +32,17 @@ func (prefix ResponseCodeDetailPrefix) Wrap(message string) string {
 	return fmt.Sprintf("%s{%s}", prefix, util.ReplaceAllEmptySpace(message))
 }
 
-type ReplyOptions struct {
+type LocalReplyOptions struct {
+	headers             http.Header
 	statusType          api.StatusType
 	responseCodeDetails string
 	grpcStatusCode      int64
 }
 
-type ReplyOption func(o *ReplyOptions)
+type LocalReplyOption func(o *LocalReplyOptions)
 
-func NewDefaultReplyOptions(opts ...ReplyOption) *ReplyOptions {
-	ro := &ReplyOptions{
+func NewLocalReplyOptions(opts ...LocalReplyOption) *LocalReplyOptions {
+	ro := &LocalReplyOptions{
 		statusType:          api.LocalReply,
 		grpcStatusCode:      -1,
 		responseCodeDetails: DefaultResponseCodeDetails,
@@ -53,27 +55,32 @@ func NewDefaultReplyOptions(opts ...ReplyOption) *ReplyOptions {
 	return ro
 }
 
-// WithResponseCodeDetails sets response code details for a request/response to the envoy context
+// LocalReplyWithRCDetails sets response code details for a request/response to the envoy context
 // It accepts a string, but commonly for convention purpose please check ResponseCodeDetailPrefix.
-func WithResponseCodeDetails(detail string) ReplyOption {
-	return func(o *ReplyOptions) {
+func LocalReplyWithRCDetails(detail string) LocalReplyOption {
+	return func(o *LocalReplyOptions) {
 		o.responseCodeDetails = detail
 	}
 }
 
-// WithGrpcStatus sets the gRPC status code for the reply options.
+// LocalReplyWithGRPCStatus sets the gRPC status code for the local reply options.
 // The status code is used to indicate the result of the gRPC operation.
-func WithGrpcStatus(status int64) ReplyOption {
-	return func(o *ReplyOptions) {
+func LocalReplyWithGRPCStatus(status int64) LocalReplyOption {
+	return func(o *LocalReplyOptions) {
 		o.grpcStatusCode = status
 	}
 }
 
-// WithStatusType sets the status type for the reply options.
-// It takes a status of type api.StatusType and returns a ReplyOption.
-// The returned ReplyOption sets the status type of the ReplyOptions object.
-func WithStatusType(status api.StatusType) ReplyOption {
-	return func(o *ReplyOptions) {
+// LocalReplyWithStatusType sets the status type for the local reply options.
+func LocalReplyWithStatusType(status api.StatusType) LocalReplyOption {
+	return func(o *LocalReplyOptions) {
 		o.statusType = status
+	}
+}
+
+// LocalReplyWithHTTPHeaders sets the HTTP headers for the local reply options.
+func LocalReplyWithHTTPHeaders(headers http.Header) LocalReplyOption {
+	return func(o *LocalReplyOptions) {
+		o.headers = headers
 	}
 }

--- a/reply_options_test.go
+++ b/reply_options_test.go
@@ -15,19 +15,19 @@ func TestResponseCodeDetailPrefix(t *testing.T) {
 	assert.Equal(t, "goext_test{foo_bar}", prefix.Wrap(msg))
 }
 
-func TestReplyOptions(t *testing.T) {
+func TestLocalReplyOptions(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		ro := NewDefaultReplyOptions()
+		ro := NewLocalReplyOptions()
 		assert.Equal(t, api.LocalReply, ro.statusType)
 		assert.Equal(t, int64(-1), ro.grpcStatusCode)
 		assert.Equal(t, DefaultResponseCodeDetails, ro.responseCodeDetails)
 	})
 
 	t.Run("custom", func(t *testing.T) {
-		ro := NewDefaultReplyOptions(
-			WithResponseCodeDetails(DefaultResponseCodeDetailInfo.Wrap("any message")),
-			WithGrpcStatus(10),
-			WithStatusType(api.StopAndBuffer),
+		ro := NewLocalReplyOptions(
+			LocalReplyWithRCDetails(DefaultResponseCodeDetailInfo.Wrap("any message")),
+			LocalReplyWithGRPCStatus(10),
+			LocalReplyWithStatusType(api.StopAndBuffer),
 		)
 
 		assert.Equal(t, api.StopAndBuffer, ro.statusType)

--- a/test/e2e/filters/custom_err_response/main.go
+++ b/test/e2e/filters/custom_err_response/main.go
@@ -32,22 +32,31 @@ type Handler struct {
 }
 
 func (h Handler) OnResponseHeader(c gonvoy.Context) error {
-	switch sc := c.Response().StatusCode; sc {
+	switch code := c.Response().StatusCode; code {
 	case http.StatusUnauthorized:
-		return c.JSON(sc,
-			gonvoy.NewMinimalJSONResponse("UNAUTHORIZED", "UNAUTHORIZED"),
-			gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader()),
-			gonvoy.WithResponseCodeDetails(gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)))
+		headers := gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader())
+		rcdetails := gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)
+
+		return c.JSON(code, gonvoy.NewMinimalJSONResponse("UNAUTHORIZED", "UNAUTHORIZED"),
+			gonvoy.LocalReplyWithHTTPHeaders(headers),
+			gonvoy.LocalReplyWithRCDetails(rcdetails))
+
 	case http.StatusTooManyRequests:
-		return c.JSON(sc,
-			gonvoy.NewMinimalJSONResponse("TOO_MANY_REQUESTS", "TOO_MANY_REQUESTS"),
-			gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader()),
-			gonvoy.WithResponseCodeDetails(gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)))
+		headers := gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader())
+		rcdetails := gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)
+
+		return c.JSON(code, gonvoy.NewMinimalJSONResponse("TOO_MANY_REQUESTS", "TOO_MANY_REQUESTS"),
+			gonvoy.LocalReplyWithHTTPHeaders(headers),
+			gonvoy.LocalReplyWithRCDetails(rcdetails))
+
 	case http.StatusServiceUnavailable:
-		return c.JSON(sc,
+		headers := gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader())
+		rcdetails := gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)
+
+		return c.JSON(code,
 			gonvoy.NewMinimalJSONResponse("SERVICE_UNAVAILABLE", "SERVICE_UNAVAILABLE"),
-			gonvoy.NewGatewayHeadersWithEnvoyHeader(c.ResponseHeader()),
-			gonvoy.WithResponseCodeDetails(gonvoy.MustGetProperty(c, "response.code_details", gonvoy.DefaultResponseCodeDetails)))
+			gonvoy.LocalReplyWithHTTPHeaders(headers),
+			gonvoy.LocalReplyWithRCDetails(rcdetails))
 	}
 
 	return nil

--- a/zz_generated.context_test.go
+++ b/zz_generated.context_test.go
@@ -451,20 +451,20 @@ func (_c *MockContext_IsResponseBodyWritable_Call) RunAndReturn(run func() bool)
 	return _c
 }
 
-// JSON provides a mock function with given fields: code, b, header, opts
-func (_m *MockContext) JSON(code int, b []byte, header http.Header, opts ...ReplyOption) error {
+// JSON provides a mock function with given fields: code, b, opts
+func (_m *MockContext) JSON(code int, b []byte, opts ...LocalReplyOption) error {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, code, b, header)
+	_ca = append(_ca, code, b)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int, []byte, http.Header, ...ReplyOption) error); ok {
-		r0 = rf(code, b, header, opts...)
+	if rf, ok := ret.Get(0).(func(int, []byte, ...LocalReplyOption) error); ok {
+		r0 = rf(code, b, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -480,22 +480,21 @@ type MockContext_JSON_Call struct {
 // JSON is a helper method to define mock.On call
 //   - code int
 //   - b []byte
-//   - header http.Header
-//   - opts ...ReplyOption
-func (_e *MockContext_Expecter) JSON(code interface{}, b interface{}, header interface{}, opts ...interface{}) *MockContext_JSON_Call {
+//   - opts ...LocalReplyOption
+func (_e *MockContext_Expecter) JSON(code interface{}, b interface{}, opts ...interface{}) *MockContext_JSON_Call {
 	return &MockContext_JSON_Call{Call: _e.mock.On("JSON",
-		append([]interface{}{code, b, header}, opts...)...)}
+		append([]interface{}{code, b}, opts...)...)}
 }
 
-func (_c *MockContext_JSON_Call) Run(run func(code int, b []byte, header http.Header, opts ...ReplyOption)) *MockContext_JSON_Call {
+func (_c *MockContext_JSON_Call) Run(run func(code int, b []byte, opts ...LocalReplyOption)) *MockContext_JSON_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]ReplyOption, len(args)-3)
-		for i, a := range args[3:] {
+		variadicArgs := make([]LocalReplyOption, len(args)-2)
+		for i, a := range args[2:] {
 			if a != nil {
-				variadicArgs[i] = a.(ReplyOption)
+				variadicArgs[i] = a.(LocalReplyOption)
 			}
 		}
-		run(args[0].(int), args[1].([]byte), args[2].(http.Header), variadicArgs...)
+		run(args[0].(int), args[1].([]byte), variadicArgs...)
 	})
 	return _c
 }
@@ -505,7 +504,7 @@ func (_c *MockContext_JSON_Call) Return(_a0 error) *MockContext_JSON_Call {
 	return _c
 }
 
-func (_c *MockContext_JSON_Call) RunAndReturn(run func(int, []byte, http.Header, ...ReplyOption) error) *MockContext_JSON_Call {
+func (_c *MockContext_JSON_Call) RunAndReturn(run func(int, []byte, ...LocalReplyOption) error) *MockContext_JSON_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -884,6 +883,64 @@ func (_c *MockContext_ResponseHeader_Call) RunAndReturn(run func() Header) *Mock
 	return _c
 }
 
+// SendResponse provides a mock function with given fields: code, bodyText, opts
+func (_m *MockContext) SendResponse(code int, bodyText string, opts ...LocalReplyOption) error {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, code, bodyText)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int, string, ...LocalReplyOption) error); ok {
+		r0 = rf(code, bodyText, opts...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockContext_SendResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendResponse'
+type MockContext_SendResponse_Call struct {
+	*mock.Call
+}
+
+// SendResponse is a helper method to define mock.On call
+//   - code int
+//   - bodyText string
+//   - opts ...LocalReplyOption
+func (_e *MockContext_Expecter) SendResponse(code interface{}, bodyText interface{}, opts ...interface{}) *MockContext_SendResponse_Call {
+	return &MockContext_SendResponse_Call{Call: _e.mock.On("SendResponse",
+		append([]interface{}{code, bodyText}, opts...)...)}
+}
+
+func (_c *MockContext_SendResponse_Call) Run(run func(code int, bodyText string, opts ...LocalReplyOption)) *MockContext_SendResponse_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]LocalReplyOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(LocalReplyOption)
+			}
+		}
+		run(args[0].(int), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockContext_SendResponse_Call) Return(_a0 error) *MockContext_SendResponse_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockContext_SendResponse_Call) RunAndReturn(run func(int, string, ...LocalReplyOption) error) *MockContext_SendResponse_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetRequestBody provides a mock function with given fields: buffer, endStream
 func (_m *MockContext) SetRequestBody(buffer api.BufferInstance, endStream bool) {
 	_m.Called(buffer, endStream)
@@ -1242,20 +1299,20 @@ func (_c *MockContext_StreamInfo_Call) RunAndReturn(run func() api.StreamInfo) *
 	return _c
 }
 
-// String provides a mock function with given fields: code, s, header, opts
-func (_m *MockContext) String(code int, s string, header http.Header, opts ...ReplyOption) error {
+// String provides a mock function with given fields: code, s, opts
+func (_m *MockContext) String(code int, s string, opts ...LocalReplyOption) error {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, code, s, header)
+	_ca = append(_ca, code, s)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int, string, http.Header, ...ReplyOption) error); ok {
-		r0 = rf(code, s, header, opts...)
+	if rf, ok := ret.Get(0).(func(int, string, ...LocalReplyOption) error); ok {
+		r0 = rf(code, s, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1271,22 +1328,21 @@ type MockContext_String_Call struct {
 // String is a helper method to define mock.On call
 //   - code int
 //   - s string
-//   - header http.Header
-//   - opts ...ReplyOption
-func (_e *MockContext_Expecter) String(code interface{}, s interface{}, header interface{}, opts ...interface{}) *MockContext_String_Call {
+//   - opts ...LocalReplyOption
+func (_e *MockContext_Expecter) String(code interface{}, s interface{}, opts ...interface{}) *MockContext_String_Call {
 	return &MockContext_String_Call{Call: _e.mock.On("String",
-		append([]interface{}{code, s, header}, opts...)...)}
+		append([]interface{}{code, s}, opts...)...)}
 }
 
-func (_c *MockContext_String_Call) Run(run func(code int, s string, header http.Header, opts ...ReplyOption)) *MockContext_String_Call {
+func (_c *MockContext_String_Call) Run(run func(code int, s string, opts ...LocalReplyOption)) *MockContext_String_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]ReplyOption, len(args)-3)
-		for i, a := range args[3:] {
+		variadicArgs := make([]LocalReplyOption, len(args)-2)
+		for i, a := range args[2:] {
 			if a != nil {
-				variadicArgs[i] = a.(ReplyOption)
+				variadicArgs[i] = a.(LocalReplyOption)
 			}
 		}
-		run(args[0].(int), args[1].(string), args[2].(http.Header), variadicArgs...)
+		run(args[0].(int), args[1].(string), variadicArgs...)
 	})
 	return _c
 }
@@ -1296,7 +1352,7 @@ func (_c *MockContext_String_Call) Return(_a0 error) *MockContext_String_Call {
 	return _c
 }
 
-func (_c *MockContext_String_Call) RunAndReturn(run func(int, string, http.Header, ...ReplyOption) error) *MockContext_String_Call {
+func (_c *MockContext_String_Call) RunAndReturn(run func(int, string, ...LocalReplyOption) error) *MockContext_String_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
it also adds new method called `SendResponse`, for handling uncommon ways to send responses, which is basically either content-type json with `JSON()` or plain text with `String()`.