### PR TITLE
chore: naming and structure

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,64 @@
+package gonvoy
+
+import (
+	"sync"
+
+	"github.com/ardikabs/gonvoy/pkg/errs"
+	"github.com/ardikabs/gonvoy/pkg/util"
+)
+
+// Cache is an interface that defines methods for storing and retrieving data in an internal cache.
+// It is designed to maintain data persistently throughout Envoy's lifespan.
+type Cache interface {
+	// Store allows you to save a value of any type under a key of any type.
+	//
+	// Please use caution! The Store function overwrites any existing data.
+	Store(key, value any)
+
+	// Load retrieves a value associated with a specific key and assigns it to the receiver.
+	//
+	// It returns true if a compatible value is successfully loaded,
+	// false if no value is found, or an error occurs during the process.
+	//
+	// If the receiver is not a pointer to the stored data type,
+	// Load will return an ErrIncompatibleReceiver.
+	//
+	// Example usage:
+	//   type mystruct struct{}
+	//
+	//   data := new(mystruct)
+	//   cache.Store("keyName", data)
+	//
+	//   receiver := new(mystruct)
+	//   _, _ = cache.Load("keyName", &receiver)
+	Load(key, receiver any) (ok bool, err error)
+}
+
+type inmemoryCache struct {
+	stash sync.Map
+}
+
+func newInternalCache() *inmemoryCache {
+	return &inmemoryCache{}
+}
+
+func (c *inmemoryCache) Store(key, value any) {
+	c.stash.Store(key, value)
+}
+
+func (c *inmemoryCache) Load(key, receiver any) (bool, error) {
+	if receiver == nil {
+		return false, errs.ErrNilReceiver
+	}
+
+	v, ok := c.stash.Load(key)
+	if !ok {
+		return false, nil
+	}
+
+	if !util.CastTo(receiver, v) {
+		return false, errs.ErrIncompatibleReceiver
+	}
+
+	return true, nil
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,61 @@
+package gonvoy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ardikabs/gonvoy/pkg/errs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache_StoreAndLoad(t *testing.T) {
+	lc := newInternalCache()
+
+	t.Run("pointer object", func(t *testing.T) {
+		source := bytes.NewReader([]byte("testing"))
+		lc.Store("foo", source)
+
+		receiver := new(bytes.Reader)
+		ok, err := lc.Load("foo", &receiver)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, source, receiver)
+	})
+
+	t.Run("literal object", func(t *testing.T) {
+		type mystruct struct{}
+		src := mystruct{}
+		lc.Store("bar", src)
+
+		dest := mystruct{}
+		ok, err := lc.Load("bar", &dest)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, src, dest)
+	})
+
+	t.Run("a nil receiver, returns an error", func(t *testing.T) {
+		ok, err := lc.Load("bar", nil)
+		assert.False(t, ok)
+		assert.ErrorIs(t, err, errs.ErrNilReceiver)
+	})
+
+	t.Run("receiver has incompatibility data type with the source, returns an error", func(t *testing.T) {
+		type mystruct struct{}
+		src := new(mystruct)
+		lc.Store("foobar", src)
+
+		dest := mystruct{}
+		ok, err := lc.Load("foobar", &dest)
+		assert.False(t, ok)
+		assert.ErrorIs(t, err, errs.ErrIncompatibleReceiver)
+	})
+
+	t.Run("if no data found during a Load, then returns false without an error", func(t *testing.T) {
+		dest := struct{}{}
+		ok, err := lc.Load("data-not-exists", &dest)
+		assert.False(t, ok)
+		assert.NoError(t, err)
+	})
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,14 +1,11 @@
 package gonvoy
 
 import (
-	"bytes"
 	"testing"
 
-	"github.com/ardikabs/gonvoy/pkg/errs"
 	mock_envoy "github.com/ardikabs/gonvoy/test/mock/envoy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConfiguration_Metrics(t *testing.T) {
@@ -21,61 +18,10 @@ func TestConfiguration_Metrics(t *testing.T) {
 		return assert.Equal(t, "prefix_foo_key=value_key1=value2", name)
 	})).Return(mock_envoy.NewGaugeMetric(t))
 
-	gc := newGlobalConfig(cc, ConfigOptions{
+	gc := newInternalConfig(cc, ConfigOptions{
 		MetricsPrefix: "PREFIX ",
 	})
 
 	gc.metricCounter("foo_key=value_key1=value2")
 	gc.metricGauge("foo_key=value_key1=value2")
-}
-
-func TestCache_StoreAndLoad(t *testing.T) {
-	lc := newCache()
-
-	t.Run("pointer object", func(t *testing.T) {
-		source := bytes.NewReader([]byte("testing"))
-		lc.Store("foo", source)
-
-		receiver := new(bytes.Reader)
-		ok, err := lc.Load("foo", &receiver)
-		require.NoError(t, err)
-		assert.True(t, ok)
-		assert.Equal(t, source, receiver)
-	})
-
-	t.Run("literal object", func(t *testing.T) {
-		type mystruct struct{}
-		src := mystruct{}
-		lc.Store("bar", src)
-
-		dest := mystruct{}
-		ok, err := lc.Load("bar", &dest)
-		require.NoError(t, err)
-		assert.True(t, ok)
-		assert.Equal(t, src, dest)
-	})
-
-	t.Run("a nil receiver, returns an error", func(t *testing.T) {
-		ok, err := lc.Load("bar", nil)
-		assert.False(t, ok)
-		assert.ErrorIs(t, err, errs.ErrNilReceiver)
-	})
-
-	t.Run("receiver has incompatibility data type with the source, returns an error", func(t *testing.T) {
-		type mystruct struct{}
-		src := new(mystruct)
-		lc.Store("foobar", src)
-
-		dest := mystruct{}
-		ok, err := lc.Load("foobar", &dest)
-		assert.False(t, ok)
-		assert.ErrorIs(t, err, errs.ErrIncompatibleReceiver)
-	})
-
-	t.Run("if no data found during a Load, then returns false without an error", func(t *testing.T) {
-		dest := struct{}{}
-		ok, err := lc.Load("data-not-exists", &dest)
-		assert.False(t, ok)
-		assert.NoError(t, err)
-	})
 }

--- a/configparser.go
+++ b/configparser.go
@@ -97,7 +97,7 @@ type ConfigOptions struct {
 
 type configParser struct {
 	options          ConfigOptions
-	rootGlobalConfig *globalConfig
+	rootGlobalConfig *internalConfig
 }
 
 func newConfigParser(options ConfigOptions) *configParser {
@@ -108,7 +108,7 @@ func newConfigParser(options ConfigOptions) *configParser {
 
 func (p *configParser) Parse(any *anypb.Any, cc api.ConfigCallbackHandler) (interface{}, error) {
 	if util.IsNil(p.options.FilterConfig) {
-		return newGlobalConfig(cc, p.options), nil
+		return newInternalConfig(cc, p.options), nil
 	}
 
 	configStruct := &xds.TypedStruct{}
@@ -132,7 +132,7 @@ func (p *configParser) Parse(any *anypb.Any, cc api.ConfigCallbackHandler) (inte
 	}
 
 	if p.rootGlobalConfig == nil {
-		p.rootGlobalConfig = newGlobalConfig(cc, p.options)
+		p.rootGlobalConfig = newInternalConfig(cc, p.options)
 		p.rootGlobalConfig.filterConfig = filterCfg
 		return p.rootGlobalConfig, nil
 	}
@@ -143,8 +143,8 @@ func (p *configParser) Parse(any *anypb.Any, cc api.ConfigCallbackHandler) (inte
 }
 
 func (p *configParser) Merge(parent, child interface{}) interface{} {
-	origParentGlobalConfig := parent.(*globalConfig)
-	origChildGlobalConfig := child.(*globalConfig)
+	origParentGlobalConfig := parent.(*internalConfig)
+	origChildGlobalConfig := child.(*internalConfig)
 
 	if util.IsNil(origParentGlobalConfig.filterConfig) {
 		return parent

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -72,7 +72,7 @@ func TestConfigParser(t *testing.T) {
 		parentCfg, err := cp.Parse(nil, mockCC)
 		require.NoError(t, err)
 
-		pConfig, ok := parentCfg.(*globalConfig)
+		pConfig, ok := parentCfg.(*internalConfig)
 		assert.True(t, ok)
 		assert.Nil(t, pConfig.filterConfig)
 	})
@@ -85,7 +85,7 @@ func TestConfigParser(t *testing.T) {
 		parentCfg, err := cp.Parse(parentConfigAny, mockCC)
 		require.NoError(t, err)
 
-		pConfig, ok := parentCfg.(*globalConfig)
+		pConfig, ok := parentCfg.(*internalConfig)
 		assert.True(t, ok)
 
 		pFilterCfg, ok := (pConfig.filterConfig).(*dummyConfig)
@@ -105,7 +105,7 @@ func TestConfigParser(t *testing.T) {
 		require.Nil(t, err)
 
 		mergedCfg := cp.Merge(parentCfg, childCfg)
-		mConfig, ok := mergedCfg.(*globalConfig)
+		mConfig, ok := mergedCfg.(*internalConfig)
 		assert.True(t, ok)
 
 		pMergedCfg, ok := (mConfig.filterConfig).(*dummyConfig)
@@ -115,11 +115,11 @@ func TestConfigParser(t *testing.T) {
 		assert.Equal(t, "child value", pMergedCfg.C)
 		assert.Equal(t, []string{"parent", "value"}, pMergedCfg.Arrays)
 
-		assert.Same(t, parentCfg.(*globalConfig).internalCache, mConfig.internalCache)
-		assert.Same(t, parentCfg.(*globalConfig).internalCache, childCfg.(*globalConfig).internalCache)
-		assert.Same(t, childCfg.(*globalConfig).internalCache, mConfig.internalCache)
-		assert.NotSame(t, parentCfg.(*globalConfig).filterConfig, mConfig.filterConfig)
-		assert.Same(t, childCfg.(*globalConfig).filterConfig, mConfig.filterConfig)
+		assert.Same(t, parentCfg.(*internalConfig).internalCache, mConfig.internalCache)
+		assert.Same(t, parentCfg.(*internalConfig).internalCache, childCfg.(*internalConfig).internalCache)
+		assert.Same(t, childCfg.(*internalConfig).internalCache, mConfig.internalCache)
+		assert.NotSame(t, parentCfg.(*internalConfig).filterConfig, mConfig.filterConfig)
+		assert.Same(t, childCfg.(*internalConfig).filterConfig, mConfig.filterConfig)
 	})
 
 	t.Run("with config | Always use Child config", func(t *testing.T) {
@@ -134,7 +134,7 @@ func TestConfigParser(t *testing.T) {
 		require.Nil(t, err)
 
 		mergedCfg := cp.Merge(parentCfg, childCfg)
-		mConfig, ok := mergedCfg.(*globalConfig)
+		mConfig, ok := mergedCfg.(*internalConfig)
 		assert.True(t, ok)
 
 		pMergedCfg, ok := (mConfig.filterConfig).(*dummyConfig)
@@ -144,18 +144,18 @@ func TestConfigParser(t *testing.T) {
 		assert.Equal(t, "child value", pMergedCfg.C)
 		assert.Empty(t, pMergedCfg.Arrays)
 
-		assert.Same(t, parentCfg.(*globalConfig).internalCache, mConfig.internalCache)
-		assert.Same(t, parentCfg.(*globalConfig).internalCache, childCfg.(*globalConfig).internalCache)
-		assert.Same(t, childCfg.(*globalConfig).internalCache, mConfig.internalCache)
-		assert.NotSame(t, parentCfg.(*globalConfig).filterConfig, mConfig.filterConfig)
-		assert.NotSame(t, parentCfg.(*globalConfig).filterConfig, childCfg.(*globalConfig).filterConfig)
+		assert.Same(t, parentCfg.(*internalConfig).internalCache, mConfig.internalCache)
+		assert.Same(t, parentCfg.(*internalConfig).internalCache, childCfg.(*internalConfig).internalCache)
+		assert.Same(t, childCfg.(*internalConfig).internalCache, mConfig.internalCache)
+		assert.NotSame(t, parentCfg.(*internalConfig).filterConfig, mConfig.filterConfig)
+		assert.NotSame(t, parentCfg.(*internalConfig).filterConfig, childCfg.(*internalConfig).filterConfig)
 		assert.NotSame(t, parentCfg, childCfg)
 		assert.NotSame(t, parentCfg, mConfig)
-		assert.Same(t, childCfg.(*globalConfig).filterConfig, mConfig.filterConfig)
+		assert.Same(t, childCfg.(*internalConfig).filterConfig, mConfig.filterConfig)
 		assert.Same(t, childCfg, mConfig)
 
-		pParentCfg := (parentCfg.(*globalConfig).filterConfig).(*dummyConfig)
-		pChildCfg := (childCfg.(*globalConfig).filterConfig).(*dummyConfig)
+		pParentCfg := (parentCfg.(*internalConfig).filterConfig).(*dummyConfig)
+		pChildCfg := (childCfg.(*internalConfig).filterConfig).(*dummyConfig)
 		assert.NotSame(t, pParentCfg.S, pChildCfg.S)
 		assert.NotSame(t, pParentCfg.S, pMergedCfg.S)
 		assert.Same(t, pChildCfg.S, pMergedCfg.S)

--- a/header_test.go
+++ b/header_test.go
@@ -61,7 +61,7 @@ func TestHeader_Export(t *testing.T) {
 	assert.Equal(t, "x-foo-bar,x-foo-bar-2", headers.Get("x-foo-bar"))
 }
 
-func TestHeader_Replace(t *testing.T) {
+func TestHeader_Import(t *testing.T) {
 	fakeHeaderMap := &fakeHeaderMap{
 		data: map[string][]string{
 			"foo":       {"bar"},
@@ -146,7 +146,7 @@ func TestNewGatewayHeaders(t *testing.T) {
 			}
 		})
 
-		ctx := fakeDummyContext(t)
+		ctx := fakeDummyContext(t, nil)
 		ctx.LoadRequestHeaders(reqHeaderMapMock)
 
 		headers := NewGatewayHeadersWithEnvoyHeader(ctx.RequestHeader())


### PR DESCRIPTION
- rename `globalConfig` to `internalConfig`, for better clarity.
- move `ContextOption` to struct because it is intended only for internal use, so there is no need to export the data type.
- move `Cache` on a separated file.