### PR TITLE
refactor: configparser for Parse and add mergeLiteral

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Test](https://github.com/ardikabs/gonvoy/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/ardikabs/gonvoy/actions/workflows/test.yaml)
 [![Codecov](https://codecov.io/gh/ardikabs/gonvoy/branch/main/graph/badge.svg)](https://codecov.io/gh/ardikabs/gonvoy)
 
-A Go framework to write an HTTP Filter extension on Envoy Proxy. It leverages the Envoy [HTTP Golang Filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/golang_filter) as its foundation.
+A thin Go framework to write an HTTP Filter extension on Envoy Proxy. It leverages the Envoy [HTTP Golang Filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/golang_filter) as its foundation.
 
 ## Features
 
@@ -49,33 +49,33 @@ go get github.com/ardikabs/gonvoy
 * Clone the project.
 
     ```bash
-    $ git clone -b plugin git@github.com:ardkabs/gonvoy.git
+    git clone -b plugin git@github.com:ardkabs/gonvoy.git
     ```
 
 * Create a meaningful branch
 
     ```bash
-    $ git checkout -b <your-meaningful-branch>
+    git checkout -b <your-meaningful-branch>
     ```
 
 * Test your changes.
 
     ```bash
-    $ make test
+    make test
     ```
 
 * We highly recommend instead of only run test, please also do audit which include formatting, linting, vetting, and testing.
 
     ```bash
-    $ make audit
+    make audit
     ```
 
 * Add, commit, and push changes to repository
 
     ```bash
-    $ git add .
-    $ git commit -s -m "<conventional commit style>"
-    $ git push origin <your-meaningful-branch>
+    git add .
+    git commit -s -m "<conventional commit style>"
+    git push origin <your-meaningful-branch>
     ```
 
     For writing commit message, please use [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) as a reference.
@@ -87,7 +87,7 @@ go get github.com/ardikabs/gonvoy
 #### Unit Test
 
 ```bash
-$ make test
+make test
 ```
 
 ### Try It

--- a/config.go
+++ b/config.go
@@ -29,9 +29,8 @@ type internalConfig struct {
 	autoReloadRoute bool
 }
 
-func newInternalConfig(cc api.ConfigCallbacks, options ConfigOptions) *internalConfig {
+func newInternalConfig(options ConfigOptions) *internalConfig {
 	gc := &internalConfig{
-		callbacks:       cc,
 		internalCache:   newInternalCache(),
 		autoReloadRoute: options.AutoReloadRoute,
 		metricsPrefix:   options.MetricsPrefix,

--- a/config_test.go
+++ b/config_test.go
@@ -18,10 +18,11 @@ func TestConfiguration_Metrics(t *testing.T) {
 		return assert.Equal(t, "prefix_foo_key=value_key1=value2", name)
 	})).Return(mock_envoy.NewGaugeMetric(t))
 
-	gc := newInternalConfig(cc, ConfigOptions{
+	gc := newInternalConfig(ConfigOptions{
 		MetricsPrefix: "PREFIX ",
 	})
 
+	gc.callbacks = cc
 	gc.defineCounterMetric("foo_key=value_key1=value2")
 	gc.defineGaugeMetric("foo_key=value_key1=value2")
 }


### PR DESCRIPTION
* `mergeLiteral` is used when a user does not provide a `FilterConfig` option. In this case, it will be supplied as a `gjson.Result`. If needed, the user can later convert it to a `map[string]interface{}` using the `result.Value()` function.



